### PR TITLE
Add sed command to use genisoimage

### DIFF
--- a/src/.vars
+++ b/src/.vars
@@ -1,0 +1,13 @@
+########################################################################
+# DO NOT TOUCH THE FOLLOWING VARIABLES UNLES YOU KNOW WHAT YOU ARE DOING
+########################################################################
+WORK_DIR="${BASE_DIR}/work"
+SRC_DIR="${BASE_DIR}/source"
+
+LINUX_BUILD_DIR="${WORK_DIR}/linux-build"
+LINUX_DIR="${LINUX_BUILD_DIR}/linux*"
+
+BUSYBOX_BUILD_DIR="${WORK_DIR}/busybox-build"
+BUSYBOX_DIR="${BUSYBOX_BUILD_DIR}/busybox*"
+
+ROOTFS="${WORK_DIR}/rootfs"

--- a/src/0_prepare.sh
+++ b/src/0_prepare.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
 
-rm -rf work
-mkdir work
+if [ -z "$BASE_DIR" ]; then
+	BASE_DIR="`pwd`"
+fi
+
+. ${BASE_DIR}/.vars
+
+rm -rf $WORK_DIR
+mkdir $WORK_DIR
 
 # -p stops errors if the directory already exists
-mkdir -p source
+mkdir -p $SRC_DIR
 

--- a/src/1_get_kernel.sh
+++ b/src/1_get_kernel.sh
@@ -1,24 +1,28 @@
 #!/bin/sh
 
-# Grab everything after the '=' character
-DOWNLOAD_URL=$(grep -i KERNEL_SOURCE_URL .config | cut -f2 -d'=')
+if [ -z "$BASE_DIR" ]; then
+	BASE_DIR="`pwd`"
+fi
+
+. $BASE_DIR/.vars
+. $BASE_DIR/.config
 
 # Grab everything after the last '/' character
-ARCHIVE_FILE=${DOWNLOAD_URL##*/}
+ARCHIVE_FILE=${KERNEL_SOURCE_URL##*/}
 
-cd source
+cd $SRC_DIR
 
 # Downloading kernel file
 # -c option allows the download to resume
-wget -c $DOWNLOAD_URL
+wget -c $KERNEL_SOURCE_URL
 
 # Delete folder with previously extracted kernel
-rm -rf ../work/kernel
-mkdir ../work/kernel
+rm -rf $LINUX_BUILD_DIR
+mkdir $LINUX_BUILD_DIR
 
 # Extract kernel to folder 'work/kernel'
 # Full path will be something like 'work/kernel/linux-3.16.1'
-tar -xvf $ARCHIVE_FILE -C ../work/kernel
+tar -xvf $ARCHIVE_FILE -C $LINUX_BUILD_DIR
 
-cd ..
+cd $BASE_DIR
 

--- a/src/2_build_kernel.sh
+++ b/src/2_build_kernel.sh
@@ -1,9 +1,13 @@
 #!/bin/sh
 
-cd work/kernel
+if [ -z "$BASE_DIR" ]; then
+	BASE_DIR="`pwd`"
+fi
 
-# Change to the first directory ls finds, e.g. 'linux-3.18.6'
-cd $(ls -d *)
+. $BASE_DIR/.vars
+
+# Enter the linux directory regardless of the version
+cd $LINUX_DIR
 
 # Cleans up the kernel sources, including configuration files
 make mrproper
@@ -20,5 +24,5 @@ sed -i "s/.*CONFIG_DEFAULT_HOSTNAME.*/CONFIG_DEFAULT_HOSTNAME=\"minimal\"/" .con
 # TODO - Suggested by Ronny Kalusniok - test this for parallel compilation: "make bzImage -j $(grep ^processor /proc/cpuinfo)".
 make bzImage
 
-cd ../../..
+cd $BASE_DIR
 

--- a/src/3_get_busybox.sh
+++ b/src/3_get_busybox.sh
@@ -1,24 +1,28 @@
 #!/bin/sh
 
-# Grab everything after the '=' character
-DOWNLOAD_URL=$(grep -i BUSYBOX_SOURCE_URL .config | cut -f2 -d'=')
+if [ -z "$BASE_DIR" ]; then
+	BASE_DIR="`pwd`"
+fi
+
+. $BASE_DIR/.vars
+. $BASE_DIR/.config
 
 # Grab everything after the last '/' character
-ARCHIVE_FILE=${DOWNLOAD_URL##*/}
+ARCHIVE_FILE=${BUSYBOX_SOURCE_URL##*/}
 
-cd source
+cd $SRC_DIR
 
 # Downloading busybox source
 # -c option allows the download to resume
-wget -c $DOWNLOAD_URL
+wget -c $BUSYBOX_SOURCE_URL
 
 # Delete folder with previously extracted busybox
-rm -rf ../work/busybox
-mkdir ../work/busybox
+rm -rf $BUSYBOX_BUILD_DIR
+mkdir $BUSYBOX_BUILD_DIR
 
 # Extract busybox to folder 'busybox'
 # Full path will be something like 'work/busybox/busybox-1.23.1'
-tar -xvf $ARCHIVE_FILE -C ../work/busybox
+tar -xvf $ARCHIVE_FILE -C $BUSYBOX_BUILD_DIR
 
-cd ..
+cd $BASE_DIR
 

--- a/src/4_build_busybox.sh
+++ b/src/4_build_busybox.sh
@@ -1,9 +1,13 @@
 #!/bin/sh
 
-cd work/busybox
+if [ -z "$BASE_DIR" ]; then
+	BASE_DIR="`pwd`"
+fi
 
-# Change to the first directory ls finds, e.g. 'busybox-1.23.1'
-cd $(ls -d *)
+. $BASE_DIR/.vars
+
+# Enter the busybox directory regardless of the version
+cd $BUSYBOX_DIR
 
 # Remove previously generated artefacts
 make clean
@@ -23,5 +27,5 @@ make busybox
 # It uses the file 'busybox.links' for this
 make install
 
-cd ../../..
+cd $BASE_DIR
 

--- a/src/5_generate_rootfs.sh
+++ b/src/5_generate_rootfs.sh
@@ -1,14 +1,19 @@
 #!/bin/sh
 
-cd work
+if [ -z "$BASE_DIR" ]; then
+	BASE_DIR="`pwd`"
+fi
+
+. $BASE_DIR/.vars
+
+cd $WORK_DIR
 
 rm -rf rootfs
 
-cd busybox
-cd $(ls -d *)
+cd $BUSYBOX_DIR
 
-cp -R _install ../../rootfs
-cd ../../rootfs
+cp -R _install $ROOTFS
+cd $ROOTFS
 
 rm -f linuxrc
 
@@ -71,10 +76,11 @@ EOF
 
 chmod +x init
 
-cp ../../*.sh src
-cp ../../.config src
+cp $BASE_DIR/*.sh src
+cp $BASE_DIR/.config src
+cp $BASE_DIR/.vars src
 chmod +r src/*.sh
 chmod +r src/.config
 
-cd ../..
+cd $BASE_DIR
 

--- a/src/6_pack_rootfs.sh
+++ b/src/6_pack_rootfs.sh
@@ -1,12 +1,18 @@
 #!/bin/sh
 
-cd work
+if [ -z "$BASE_DIR" ]; then
+	BASE_DIR="`pwd`"
+fi
+
+. $BASE_DIR/.vars
+
+cd $WORK_DIR
 
 rm -f rootfs.cpio.gz
 
-cd rootfs
+cd $ROOTFS
 
-find . | cpio -H newc -o | gzip > ../rootfs.cpio.gz
+find . | cpio -H newc -o | gzip > $WORK_DIR/rootfs.cpio.gz
 
-cd ../..
+cd $BASE_DIR
 

--- a/src/7_generate_iso.sh
+++ b/src/7_generate_iso.sh
@@ -5,6 +5,9 @@ rm -f minimal_linux_live.iso
 cd work/kernel
 cd $(ls -d *)
 
+# Edit Makefile to look for genisoimage instead of mkisofs
+sed -i 's/mkisofs/genisoimage/g' arch/x86/boot/Makefile
+
 make isoimage FDINITRD=../../rootfs.cpio.gz
 cp arch/x86/boot/image.iso ../../../minimal_linux_live.iso
 

--- a/src/7_generate_iso.sh
+++ b/src/7_generate_iso.sh
@@ -1,15 +1,24 @@
 #!/bin/sh
 
+if [ -z "$BASE_DIR" ]; then
+	BASE_DIR="`pwd`"
+fi
+
+. $BASE_DIR/.vars
+
 rm -f minimal_linux_live.iso
 
-cd work/kernel
-cd $(ls -d *)
+cd $LINUX_DIR
 
-# Edit Makefile to look for genisoimage instead of mkisofs
+if [ -z `which mkisofs` ]; then
+	alias mkisofs="genisoimage"
+fi
+
+# Force Makefile to look for genisoimage instead of isoimage
 sed -i 's/mkisofs/genisoimage/g' arch/x86/boot/Makefile
 
-make isoimage FDINITRD=../../rootfs.cpio.gz
-cp arch/x86/boot/image.iso ../../../minimal_linux_live.iso
+make isoimage FDINITRD=$WORK_DIR/rootfs.cpio.gz
+cp arch/x86/boot/image.iso $BASE_DIR/minimal_linux_live.iso
 
-cd ../../..
+cd $BASE_DIR
 

--- a/src/build_minimal_linux_live.sh
+++ b/src/build_minimal_linux_live.sh
@@ -1,4 +1,4 @@
-#BASE_DIR/biBASE_DIR/sh
+#!/bin/sh
 
 # Save current directory
 BASE_DIR="`pwd`"

--- a/src/build_minimal_linux_live.sh
+++ b/src/build_minimal_linux_live.sh
@@ -1,10 +1,13 @@
-#!/bin/sh
+#BASE_DIR/biBASE_DIR/sh
 
-sh 0_prepare.sh
-sh 1_get_kernel.sh
-sh 2_build_kernel.sh
-sh 3_get_busybox.sh
-sh 4_build_busybox.sh
-sh 5_generate_rootfs.sh
-sh 6_pack_rootfs.sh
-sh 7_generate_iso.sh
+# Save current directory
+BASE_DIR="`pwd`"
+
+. $BASE_DIR/0_prepare.sh
+. $BASE_DIR/1_get_kernel.sh
+. $BASE_DIR/2_build_kernel.sh
+. $BASE_DIR/3_get_busybox.sh
+. $BASE_DIR/4_build_busybox.sh
+. $BASE_DIR/5_generate_rootfs.sh
+. $BASE_DIR/6_pack_rootfs.sh
+. $BASE_DIR/7_generate_iso.sh


### PR DESCRIPTION
This change fixes a bug by adding a sed command to force the arch/x86/boot/Makefile to use genisoimage instead of mkisofs.