### PR TITLE
Add sed command to use genisoimage

### DIFF
--- a/src/7_generate_iso.sh
+++ b/src/7_generate_iso.sh
@@ -5,6 +5,9 @@ rm -f minimal_linux_live.iso
 cd work/kernel
 cd $(ls -d *)
 
+# Edit Makefile to look for genisoimage instead of mkisofs
+sed -i 's/mkisofs/genisoimage/g' arch/x86/boot/Makefile
+
 make isoimage FDINITRD=../../rootfs.cpio.gz
 cp arch/x86/boot/image.iso ../../../minimal_linux_live.iso
 


### PR DESCRIPTION
This change fixes a bug by adding a sed command to force the arch/x86/boot/Makefile to use genisoimage instead of mkisofs. This directly fixes Debian systems.