### PR TITLE
Use -m 128M for qemu-system-x86_64

### DIFF
--- a/src/qemu64.sh
+++ b/src/qemu64.sh
@@ -7,11 +7,12 @@
 # have hard disk image, you can use it as overlay device and persist all your
 # changes. See the '.config' file for more information on the overlay support.
 
+cmd="qemu-system-x86_64 -enable-kvm -m 128M -cdrom minimal_linux_live.iso -boot d -vga std"
 if [ "$1" = "-hdd" -o "$1" = "-h" ] ; then
   echo "Starting QEMU with attached ISO image and hard disk."
-  qemu-system-x86_64 -m 64M -cdrom minimal_linux_live.iso -hda hdd.img -boot d -vga std
+  $cmd -hda hdd.img
 else
   echo "Starting QEMU with attached ISO image."
-  qemu-system-x86_64 -m 64M -cdrom minimal_linux_live.iso -boot d -vga std
+  $cmd
 fi
 


### PR DESCRIPTION
Otherwise boot fails with:

    Kernel panic - not syncing: VFS: Unable to mount root fs or unknown-block(0,0)

Tested on Ubuntu 16.04.