### PR TITLE
Add Nano & Ncurses

### DIFF
--- a/src/.config
+++ b/src/.config
@@ -1,52 +1,3 @@
-# If this is the first time you build "Minimal Linux Live", then I suggest you
-# go through the README file first.
-
-###################################################
-#                                                 #
-#  This section contains the main source bundles  #
-#                                                 #
-###################################################
-
-# You can find the latest Linux kernel source bundles here:
-#
-#   http://kernel.org
-#
-KERNEL_SOURCE_URL=http://kernel.org/pub/linux/kernel/v4.x/linux-4.8.1.tar.xz
-
-# You can find the latest GNU libc source bundles here:
-#
-#   http://gnu.org/software/libc
-#
-GLIBC_SOURCE_URL=http://ftp.gnu.org/gnu/glibc/glibc-2.24.tar.bz2
-
-# You can find the latest BusyBox source bundles here:
-#
-#   http://busybox.net
-#
-BUSYBOX_SOURCE_URL=http://busybox.net/downloads/busybox-1.25.1.tar.bz2
-
-# You can find the latest Syslinux source bundles here:
-#
-#   http://syslinux.org (official website)
-#
-#   http://kernel.org/pub/linux/utils/boot/syslinux
-#
-SYSLINUX_SOURCE_URL=http://kernel.org/pub/linux/utils/boot/syslinux/syslinux-6.03.tar.xz
-
-
-
-#####################################################################
-#                                                                   #
-#  This section contains the overlay source bundles and properties  #
-#                                                                   #
-#####################################################################
-
-# You can find the latest Links source bundles here:
-#
-#   http://links.twibright.com
-#
-LINKS_SOURCE_URL=http://links.twibright.com/download/links-2.13.tar.bz2
-
 # You can find the latest Dropbear source bundles here:
 #
 #   http://matt.ucc.asn.au/dropbear/dropbear.html
@@ -66,6 +17,17 @@ FELIX_SOURCE_URL=http://www-us.apache.org/dist/felix/org.apache.felix.main.distr
 #
 #JAVA_ARCHIVE=/absolute/path/to/java.archive.tar.gz
 
+# You can find the latest Ncurses source bundles here:
+#
+#	http://ftp.gnu.org
+#
+NCURSES_SOURCE_URL=http://ftp.gnu.org/gnu/ncurses/ncurses-6.0.tar.gz
+
+# You can find the latest Nano source bundles here:
+#
+#	http://nano-editor.org
+#
+NANO_SOURCE_URL=http://nano-editor.org/dist/v2.6/nano-2.6.3.tar.xz
 
 
 ####################################################
@@ -149,11 +111,13 @@ COPY_SOURCE_ISO=true
 # java       - installs Oracle's JRE or JDK. Manual preparations are required.
 # felix      - Apache Felix OSGi framework.
 # mll_utils  - set of executable utilities (mll-*).
+# ncurses    - text library for applications such as nano and dialog.
+# nano       - small text editor alternative to vi.
 #
 # Refer to the README file for more information.
 #
 #OVERLAY_BUNDLES=glibc_full,links,dropbear,java,felix,mll_utils
-#OVERLAY_BUNDLES=mll_utils
+#OVERLAY_BUNDLES=glibc_full,links,dropbear,mll_utils,ncurses,nano
 
 # This property enables the standard penguin boot logo in the upper left corner
 # of the screen. The property is used in 'xx_build_kernel.sh'. The default value

--- a/src/.config
+++ b/src/.config
@@ -1,3 +1,52 @@
+# If this is the first time you build "Minimal Linux Live", then I suggest you
+# go through the README file first.
+
+###################################################
+#                                                 #
+#  This section contains the main source bundles  #
+#                                                 #
+###################################################
+
+# You can find the latest Linux kernel source bundles here:
+#
+#   http://kernel.org
+#
+KERNEL_SOURCE_URL=http://kernel.org/pub/linux/kernel/v4.x/linux-4.8.1.tar.xz
+
+# You can find the latest GNU libc source bundles here:
+#
+#   http://gnu.org/software/libc
+#
+GLIBC_SOURCE_URL=http://ftp.gnu.org/gnu/glibc/glibc-2.24.tar.bz2
+
+# You can find the latest BusyBox source bundles here:
+#
+#   http://busybox.net
+#
+BUSYBOX_SOURCE_URL=http://busybox.net/downloads/busybox-1.25.1.tar.bz2
+
+# You can find the latest Syslinux source bundles here:
+#
+#   http://syslinux.org (official website)
+#
+#   http://kernel.org/pub/linux/utils/boot/syslinux
+#
+SYSLINUX_SOURCE_URL=http://kernel.org/pub/linux/utils/boot/syslinux/syslinux-6.03.tar.xz
+
+
+
+#####################################################################
+#                                                                   #
+#  This section contains the overlay source bundles and properties  #
+#                                                                   #
+#####################################################################
+
+# You can find the latest Links source bundles here:
+#
+#   http://links.twibright.com
+#
+LINKS_SOURCE_URL=http://links.twibright.com/download/links-2.13.tar.bz2
+
 # You can find the latest Dropbear source bundles here:
 #
 #   http://matt.ucc.asn.au/dropbear/dropbear.html

--- a/src/README
+++ b/src/README
@@ -48,6 +48,17 @@ Currently available overlay bundles:
                the "felix-start" command to run the Apache Felix OSGi framework. 
 
                This overlay bundle requires JRE or JDK.
+               
+* Ncurses    - GNU New Curses (Ncurses) Library. Requires ~3MB additional space
+               for Ncurses. Provides libraries for Nano and Dialog and main 
+               GUI-Like Framework.
+               
+               This overlay bundle requires GLIBC.
+               
+* Nano       - GNU Nano Text Editor. Requires ~2MB additional space. Use the
+               "nano" command to start the Nano text editor. Alternative to Vi.
+               
+               This overlay bundle requires Ncurses.
 
 ###   ###   ###
 

--- a/src/overlay_nano.sh
+++ b/src/overlay_nano.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+time sh overlay_nano_01_get.sh
+time sh overlay_nano_02_build.sh
+

--- a/src/overlay_nano_01_get.sh
+++ b/src/overlay_nano_01_get.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+SRC_DIR=$(pwd)
+
+# Grab everything after the '=' character.
+DOWNLOAD_URL=$(grep -i NANO_SOURCE_URL .config | cut -f2 -d'=')
+
+# Grab everything after the last '/' character.
+ARCHIVE_FILE=${DOWNLOAD_URL##*/}
+
+# Read the 'USE_LOCAL_SOURCE' property from '.config'
+USE_LOCAL_SOURCE="$(grep -i USE_LOCAL_SOURCE .config | cut -f2 -d'=')"
+
+if [ "$USE_LOCAL_SOURCE" = "true" -a ! -f $SRC_DIR/source/overlay/$ARCHIVE_FILE  ] ; then
+  echo "Source bundle $SRC_DIR/source/overlay/$ARCHIVE_FILE is missing and will be downloaded."
+  USE_LOCAL_SOURCE="false"
+fi
+
+cd source/overlay
+
+if [ ! "$USE_LOCAL_SOURCE" = "true" ] ; then
+  # Downloading Nano source bundle file. The '-c' option allows the download to resume.
+  echo "Downloading Nano source bundle from $DOWNLOAD_URL"
+  wget -c $DOWNLOAD_URL
+else
+  echo "Using local Nano source bundle $SRC_DIR/source/overlay/$ARCHIVE_FILE"
+fi
+
+# Delete folder with previously extracted Nano.
+echo "Removing Nano work area. This may take a while..."
+rm -rf ../../work/overlay/nano
+mkdir ../../work/overlay/nano
+
+# Extract Nano to folder 'work/overlay/nano'.
+# Full path will be something like 'work/overlay/nano/nano-2.6.3'.
+tar -xvf $ARCHIVE_FILE -C ../../work/overlay/nano
+
+cd $SRC_DIR

--- a/src/overlay_nano_02_build.sh
+++ b/src/overlay_nano_02_build.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+SRC_DIR=$(pwd)
+
+# Read the 'JOB_FACTOR' property from '.config'
+JOB_FACTOR="$(grep -i ^JOB_FACTOR .config | cut -f2 -d'=')"
+
+# Find the number of available CPU cores.
+NUM_CORES=$(grep ^processor /proc/cpuinfo | wc -l)
+
+# Calculate the number of 'make' jobs to be used later.
+NUM_JOBS=$((NUM_CORES * JOB_FACTOR))
+
+cd work/overlay/nano
+
+# Change to the Nano source directory which ls finds, e.g. 'nano-2.6.3'.
+cd $(ls -d nano-*)
+
+echo "Preparing Nano work area. This may take a while..."
+make clean -j $NUM_JOBS 2>/dev/null
+
+rm -rf ../nano_installed
+
+echo "Configuring Nano..."
+./configure \
+	--prefix=$SRC_DIR/work/overlay/nano/nano_installed \
+	--disable-utf8 \
+    CFLAGS="-Os -s -fno-stack-protector -U_FORTIFY_SOURCE"
+
+echo "Building Nano..."
+make -j $NUM_JOBS
+
+echo "Installing Nano..."
+make install -j $NUM_JOBS
+
+echo "Reducing Nano size..."
+strip -g ../nano_installed/bin/* 2>/dev/null
+
+cp -r ../nano_installed/bin $SRC_DIR/work/src/minimal_overlay
+echo "Nano has been installed."
+
+# Configure Nano.
+echo "set autoindent" >> $SRC_DIR/work/src/overlay/etc/nanorc
+echo "set const" >> $SRC_DIR/work/src/overlay/etc/nanorc
+echo "set fill 72" >> $SRC_DIR/work/src/overlay/etc/nanorc
+echo "set historylog" >> $SRC_DIR/work/src/overlay/etc/nanorc
+echo "set multibuffer" >> $SRC_DIR/work/src/overlay/etc/nanorc
+echo "set nohelp" >> $SRC_DIR/work/src/overlay/etc/nanorc
+echo "set regexp" >> $SRC_DIR/work/src/overlay/etc/nanorc
+echo "set smooth" >> $SRC_DIR/work/src/overlay/etc/nanorc
+echo "set suspend" >> $SRC_DIR/work/src/overlay/etc/nanorc
+
+cd $SRC_DIR

--- a/src/overlay_ncurses.sh
+++ b/src/overlay_ncurses.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 time sh overlay_ncurses_01_get.sh
-time sh overlay_ncurses_02_build.s
+time sh overlay_ncurses_02_build.sh

--- a/src/overlay_ncurses.sh
+++ b/src/overlay_ncurses.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+time sh overlay_ncurses_01_get.sh
+time sh overlay_ncurses_02_build.s

--- a/src/overlay_ncurses_01_get.sh
+++ b/src/overlay_ncurses_01_get.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+SRC_DIR=$(pwd)
+
+# Grab everything after the '=' character.
+DOWNLOAD_URL=$(grep -i NCURSES_SOURCE_URL .config | cut -f2 -d'=')
+
+# Grab everything after the last '/' character.
+ARCHIVE_FILE=${DOWNLOAD_URL##*/}
+
+# Read the 'USE_LOCAL_SOURCE' property from '.config'
+USE_LOCAL_SOURCE="$(grep -i USE_LOCAL_SOURCE .config | cut -f2 -d'=')"
+
+if [ "$USE_LOCAL_SOURCE" = "true" -a ! -f $SRC_DIR/source/overlay/$ARCHIVE_FILE  ] ; then
+  echo "Source bundle $SRC_DIR/source/overlay/$ARCHIVE_FILE is missing and will be downloaded."
+  USE_LOCAL_SOURCE="false"
+fi
+
+cd source/overlay
+
+if [ ! "$USE_LOCAL_SOURCE" = "true" ] ; then
+  # Downloading Links source bundle file. The '-c' option allows the download to resume.
+  echo "Downloading Ncurses source bundle from $DOWNLOAD_URL"
+  wget -c $DOWNLOAD_URL
+else
+  echo "Using local Ncurses source bundle $SRC_DIR/source/overlay/$ARCHIVE_FILE"
+fi
+
+# Delete folder with previously extracted Ncurses.
+echo "Removing Ncurses work area. This may take a while..."
+rm -rf ../../work/overlay/ncurses
+mkdir ../../work/overlay/ncurses
+
+# Extract Links to folder 'work/overlay/ncurses'.
+# Full path will be something like 'work/overlay/links/ncurses-6.0'.
+tar -xvf $ARCHIVE_FILE -C ../../work/overlay/ncurses
+
+cd $SRC_DIR

--- a/src/overlay_ncurses_02_build.sh
+++ b/src/overlay_ncurses_02_build.sh
@@ -26,15 +26,15 @@ rm -rf ../ncurses_installed
 
 echo "Configuring Links..."
 ./configure \
-	--prefix=../ncurses_installed \
-	--with-termlib \
+    --prefix=$SRC_DIR/work/overlay/ncurses/ncurses_installed \
+    --with-termlib \
     --with-shared \
     --with-terminfo-dirs=/lib/terminfo \
     --with-default-terminfo-dirs=/lib/terminfo \
     --without-normal \
     --without-debug \
     --without-cxx-binding \
-	--with-abi-version=5 \
+    --with-abi-version=5 \
     CFLAGS="-Os -s -fno-stack-protector -U_FORTIFY_SOURCE" \
     CPPFLAGS="-P"
 
@@ -47,10 +47,11 @@ make install -j $NUM_JOBS
 echo "Reducing Ncurses size..."
 strip -g ../ncurses_installed/bin/* 2>/dev/null
 strip -g ../ncurses_installed/lib/* 2>/dev/null
+strip -g ../ncurses_installed/share/* 2>/dev/null
 
 cp -r ../ncurses_installed/bin $SRC_DIR/work/src/minimal_overlay
 cp -r ../ncurses_installed/lib $SRC_DIR/work/src/minimal_overlay
-cp -r ../ncurses_installed/share/terminfo $SRC_DIR/work/src/minimal_overlay/lib
+cp -r ../ncurses_installed/share $SRC_DIR/work/src/minimal_overlay
 echo "Ncurses has been installed."
 
 cd $SRC_DIR

--- a/src/overlay_ncurses_02_build.sh
+++ b/src/overlay_ncurses_02_build.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+SRC_DIR=$(pwd)
+
+# Read the 'JOB_FACTOR' property from '.config'
+JOB_FACTOR="$(grep -i ^JOB_FACTOR .config | cut -f2 -d'=')"
+
+# Find the number of available CPU cores.
+NUM_CORES=$(grep ^processor /proc/cpuinfo | wc -l)
+
+# Calculate the number of 'make' jobs to be used later.
+NUM_JOBS=$((NUM_CORES * JOB_FACTOR))
+
+cd work/overlay/ncurses
+
+# Change to the Links source directory which ls finds, e.g. 'ncurses-6.0'.
+cd $(ls -d ncurses-*)
+
+echo "Preparing Ncurses work area. This may take a while..."
+make clean -j $NUM_JOBS 2>/dev/null
+
+# Configure Ncurses to not make libraries it can't support.
+sed -i '/LIBTOOL_INSTALL/d' c++/Makefile.in
+
+rm -rf ../ncurses_installed
+
+echo "Configuring Links..."
+./configure \
+	--prefix=../ncurses_installed \
+	--with-termlib \
+    --with-shared \
+    --with-terminfo-dirs=/lib/terminfo \
+    --with-default-terminfo-dirs=/lib/terminfo \
+    --without-normal \
+    --without-debug \
+    --without-cxx-binding \
+	--with-abi-version=5 \
+    CFLAGS="-Os -s -fno-stack-protector -U_FORTIFY_SOURCE" \
+    CPPFLAGS="-P"
+
+echo "Building Ncurses..."
+make -j $NUM_JOBS
+
+echo "Installing Ncurses..."
+make install -j $NUM_JOBS
+
+echo "Reducing Ncurses size..."
+strip -g ../ncurses_installed/bin/* 2>/dev/null
+strip -g ../ncurses_installed/lib/* 2>/dev/null
+
+cp -r ../ncurses_installed/bin $SRC_DIR/work/src/minimal_overlay
+cp -r ../ncurses_installed/lib $SRC_DIR/work/src/minimal_overlay
+cp -r ../ncurses_installed/share/terminfo $SRC_DIR/work/src/minimal_overlay/lib
+echo "Ncurses has been installed."
+
+cd $SRC_DIR


### PR DESCRIPTION
After experimenting with a separate repository (AwlsomeAlex/AwlsomeLinux) and countless hours of debugging, I've finally managed to add support for Ncurses and Nano. Now what are the benefits? An alternative text editor (Due to Vi being very user-unfriendly) and support for other software bundles like Dialog, and basically everything that uses the command-line as a GUI. It's up to you if you want to add it to the master branch, but it isn't a bad idea to at lease keep ncurses, because there is minimal documentation about compiling it correctly for this scenario, and it opens the gate to things such as Nano, Dialog, etc. All up to you. 