### PR TITLE
Fixed Typo for Kernel Build

### DIFF
--- a/src/02_build_kernel.sh
+++ b/src/02_build_kernel.sh
@@ -82,7 +82,7 @@ else
   # The '$?' variable holds the exit code of the last issued command.
   if [ $? = 1 ] ; then
     # Enable the mixed EFI mode when building 64-bit kernel.
-    echo "CONFIG_EFI_MIXED=y" > .config
+    echo "CONFIG_EFI_MIXED=y" >> .config
   fi
 fi
 


### PR DESCRIPTION
Due to "CONFIG_EFI_MIXED=y" being echoed to the .config by just one >, it was overwriting the .config file, causing the user to have to manually configure it again. Now with it >> it adds the text at end of the file. Untested but logically makes sense.