### PR TITLE
Fixed Kernel 4.10 =< Support

### DIFF
--- a/src/02_build_kernel.sh
+++ b/src/02_build_kernel.sh
@@ -52,6 +52,9 @@ else
   # Enable overlay support, e.g. merge ro and rw directories.
   sed -i "s/.*CONFIG_OVERLAY_FS.*/CONFIG_OVERLAY_FS=y/" .config
   
+  # Enable overlayfs redirection 
+  echo "CONFIG_OVERLAY_FS_REDIRECT_DIR=y" >> .config
+  
   # Step 1 - disable all active kernel compression options (should be only one).
   sed -i "s/.*\\(CONFIG_KERNEL_.*\\)=y/\\#\\ \\1 is not set/" .config  
   
@@ -77,6 +80,9 @@ else
 
   # Enable the EFI stub
   sed -i "s/.*CONFIG_EFI_STUB.*/CONFIG_EFI_STUB=y/" .config
+  
+  # Disable Apple Properties (Useful for Macs but useless in general)
+  echo "CONFIG_APPLE_PROPERTIES=n" >> .config
 
   # Check if we are building 32-bit kernel. The exit code is '1' when we are
   # building 64-bit kernel, otherwise the exit code is '0'.


### PR DESCRIPTION
These two configurations are not set in the default .config for Linux Kernel version 4.10 =< and would require user input in order for the script to continue, basically all this small change does is fill in those missing configuration values so the script doesn't have to wait for user input. 

I'd like to note I'm not entirely sure what `CONFIG_OVERLAY_FS_REDIRECT_DIR` is or how it would affect Minimal Linux Live (As I don't use OverlayFS any-more) so this one configuration may need to be tested with both options before it is pulled into the master branch. I can note that unless you're compiling a Linux Kernel for a Mac, `CONFIG_APPLE_PROPERTIES` can remain disabled.