### PR TITLE
Added kexec-tools

### DIFF
--- a/src/.config
+++ b/src/.config
@@ -110,6 +110,11 @@ UTIL_LINUX_SOURCE_URL=https://www.kernel.org/pub/linux/utils/util-linux/v2.31/ut
 #
 ZLIB_SOURCE_URL=http://zlib.net/zlib-1.2.11.tar.xz
 
+# You can find the latest kexec-tools source bundles here:
+#
+#   https://www.kernel.org/pub/linux/utils/kernel/kexec/
+##
+KEXEC_TOOLS_SOURCE_URL=http://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.15.tar.xz
 
 
 ####################################################

--- a/src/minimal_overlay/bundles/kexec-tools/01_get.sh
+++ b/src/minimal_overlay/bundles/kexec-tools/01_get.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+SRC_DIR=$(pwd)
+
+. ../../common.sh
+
+# Grab everything after the '=' character.
+DOWNLOAD_URL=$(grep -i KEXEC_TOOLS_SOURCE_URL $MAIN_SRC_DIR/.config | cut -f2 -d'=')
+
+# Grab everything after the last '/' character.
+ARCHIVE_FILE=${DOWNLOAD_URL##*/}
+echo "ARCHIVE_FILE='${ARCHIVE_FILE}'"
+# Read the 'USE_LOCAL_SOURCE' property from '.config'
+USE_LOCAL_SOURCE="$(grep -i USE_LOCAL_SOURCE $MAIN_SRC_DIR/.config | cut -f2 -d'=')"
+
+if [ "$USE_LOCAL_SOURCE" = "true" -a ! -f $MAIN_SRC_DIR/source/overlay/$ARCHIVE_FILE  ] ; then
+  echo "Source bundle $MAIN_SRC_DIR/source/overlay/$ARCHIVE_FILE is missing and will be downloaded."
+  USE_LOCAL_SOURCE="false"
+fi
+
+cd $MAIN_SRC_DIR/source/overlay
+
+if [ ! "$USE_LOCAL_SOURCE" = "true" ] ; then
+  # Downloading the kexec-tools bundle file. The '-c' option allows the download to resume.
+  echo "Downloading kexec-tools source bundle from $DOWNLOAD_URL"
+  wget -c $DOWNLOAD_URL
+else
+  echo "Using local kexec-tools source bundle $MAIN_SRC_DIR/source/overlay/$ARCHIVE_FILE"
+fi
+
+# Delete folder with previously extracted kexec-tools.
+echo "Removing kexec-tools work area. This may take a while..."
+rm -rf $WORK_DIR/overlay/kexec-tools
+mkdir $WORK_DIR/overlay/kexec-tools
+
+# Extract kexec-tools to folder 'work/overlay/kexec-tools'.
+# Full path will be something like 'work/overlay/kexec-tools/kexec-tools-2.0.15'.
+tar -xvf $ARCHIVE_FILE -C $WORK_DIR/overlay/kexec-tools
+
+cd $SRC_DIR

--- a/src/minimal_overlay/bundles/kexec-tools/02_build.sh
+++ b/src/minimal_overlay/bundles/kexec-tools/02_build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+SRC_DIR=$(pwd)
+
+. ../../common.sh
+
+cd $WORK_DIR/overlay/kexec-tools
+
+DESTDIR="$PWD/kexec-tools_installed"
+
+# Change to the kexec-tools source directory which ls finds, e.g. 'kexec-tools-2.0.15'.
+cd $(ls -d kexec-tools-*)
+
+echo "Preparing kexec-tools work area. This may take a while..."
+make -j $NUM_JOBS clean
+rm -rf $DESTDIR
+
+echo "Building kexec-tools..."
+CFLAGS="$CFLAGS" ./configure \
+  --prefix=/usr \
+  --without-lzama
+
+make -j $NUM_JOBS
+
+make -j $NUM_JOBS install DESTDIR="$DESTDIR"
+
+echo "Reducing kexec-tools size..."
+strip -g $DESTDIR/usr/bin/* \
+  $DESTDIR/usr/lib/* 2>/dev/null
+
+ROOTFS="$WORK_DIR/src/minimal_overlay/rootfs"
+mkdir -p $ROOTFS/usr/
+cp -r $DESTDIR/usr/* $ROOTFS/usr/
+
+echo "kexec-tools has been installed."
+
+cd $SRC_DIR

--- a/src/minimal_overlay/bundles/kexec-tools/bundle.sh
+++ b/src/minimal_overlay/bundles/kexec-tools/bundle.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+SRC_DIR=$(pwd)
+
+./01_get.sh
+./02_build.sh
+
+cd $SRC_DIR


### PR DESCRIPTION
You can use this (for example) to "fast" reboot minimal linux:
```bash
kexec -l /tmp/mnt/device/kernel.xz --initrd /tmp/mnt/device/rootfs.xz --reuse-cmdline
killall5
umount -ar
kexec -e
```

kexec-tools has a few issues when using a vga mode other than the standard