### PR TITLE
Clean up .config and README

### DIFF
--- a/src/.config
+++ b/src/.config
@@ -41,11 +41,11 @@ SYSLINUX_SOURCE_URL=http://kernel.org/pub/linux/utils/boot/syslinux/syslinux-6.0
 #                                                                   #
 #####################################################################
 
-# You can find the latest Links source bundles here:
+# You can find the latest Cloud Foundry CLI binary here:
 #
-#   http://links.twibright.com
+#   http://github.com/cloudfoundry/cli
 #
-LINKS_SOURCE_URL=http://links.twibright.com/download/links-2.14.tar.bz2
+CLOUD_FOUNDRY_CLI_URL=http://cli.run.pivotal.io/stable?release=linux64-binary&source=github
 
 # You can find the latest Dropbear source bundles here:
 #
@@ -67,6 +67,18 @@ FELIX_SOURCE_URL=http://archive.apache.org/dist/felix/org.apache.felix.main.dist
 #JAVA_ARCHIVE=/absolute/path/to/java.archive.tar.gz
 #JAVA_ARCHIVE=/home/ivan/Downloads/jdk-9_linux-x64_bin.tar.gz
 
+# You can find the latest kexec-tools source bundles here:
+#
+#   https://www.kernel.org/pub/linux/utils/kernel/kexec/
+#
+KEXEC_TOOLS_SOURCE_URL=http://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.15.tar.xz
+
+# You can find the latest Links source bundles here:
+#
+#   http://links.twibright.com
+#
+LINKS_SOURCE_URL=http://links.twibright.com/download/links-2.14.tar.bz2
+
 # You can find the latest Lua source bundes here:
 #
 #   https://www.lua.org/ftp/
@@ -85,24 +97,18 @@ NANO_SOURCE_URL=https://nano-editor.org/dist/v2.8/nano-2.8.7.tar.xz
 #
 NCURSES_SOURCE_URL=https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.0.tar.gz
 
+# You can find the latest Open JDK archives here:
+#
+#   http://jdk.java.net/9
+#
+OPENJDK_URL=http://download.java.net/java/GA/jdk9/9/binaries/jdk-9+181_linux-x64_bin.tar.gz
+
 # You can find the latest static-get shell script here:
 #
 #   http://s.minos.io/s
 #   http://github.com/minos-org/minos-static
 #
 STATIC_GET_SOURCE_URL=http://s.minos.io/s
-
-# You can find the latest Cloud Foundry CLI binary here:
-#
-#   http://github.com/cloudfoundry/cli
-#
-CLOUD_FOUNDRY_CLI_URL=http://cli.run.pivotal.io/stable?release=linux64-binary&source=github
-
-# You can find the latest Open JDK archives here:
-#
-#   http://jdk.java.net/9
-#
-OPENJDK_URL=http://download.java.net/java/GA/jdk9/9/binaries/jdk-9+181_linux-x64_bin.tar.gz
 
 # You can find the latest util_linux archives here:
 #
@@ -115,12 +121,6 @@ UTIL_LINUX_SOURCE_URL=https://www.kernel.org/pub/linux/utils/util-linux/v2.31/ut
 #   http://zlib.net
 #
 ZLIB_SOURCE_URL=http://zlib.net/zlib-1.2.11.tar.xz
-
-# You can find the latest kexec-tools source bundles here:
-#
-#   https://www.kernel.org/pub/linux/utils/kernel/kexec/
-##
-KEXEC_TOOLS_SOURCE_URL=http://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.15.tar.xz
 
 
 ####################################################
@@ -199,26 +199,26 @@ COPY_SOURCE_ISO=true
 # Currently available overlay software:
 #
 # glibc_full - all core GNU C libraries (useful if other software is included).
-# links      - text browser for the web.
+# cf_cli     - CLoud Foundry CLI (command line interface).
+# dhcp       - DHCP and DNS functionality.
 # dropbear   - SSH server and client.
-# java       - installs Oracle's JRE or JDK. Manual preparations are required.
-# openjdk    - installs Open JDK. All operations are automated.
 # felix      - Apache Felix OSGi framework.
+# java       - installs Oracle's JRE or JDK. Manual preparations are required.
+# links      - text browser for the web.
+# lua        - scripting language.
 # mll_utils  - set of executable utilities (mll-*).
-# nano       - GNU nano is an enhanced clone of the Pico text editor
-# ncurses    - "GUI-like" API that runs within a terminal emulator
-# lua        - scripting language
-# static_get - portable binaries for Linux (http://s.minos.io)
-# cf_cli     - CLoud Foundry CLI (command line interface)
-# nweb       - simple mini http server
-# dhcp       - DHCP and DNS functionality
-# util_linux - standard package distributed by the Linux Kernel Organization.
+# nano       - simple command-line text editor with on-screen shortcuts.git 
+# ncurses    - "GUI-like" API that runs within a terminal emulator.
+# nweb       - simple mini http server.
+# openjdk    - installs Open JDK. All operations are automated.
+# static_get - portable binaries for Linux (http://s.minos.io).
+# util_linux - set of executable utilities distributed by the Linux Kernel Org.
 # zlib       - DEFLATE compression/decompression library.
 #
 # Refer to the README file for more information.
 #
-#OVERLAY_BUNDLES=glibc_full,links,dropbear,java,felix,mll_utils,nano,lua,static_get,cf_cli,ncurses,util_linux,nweb,dhcp
-#OVERLAY_BUNDLES=dhcp,glibc_full,zlib,openjdk,felix,links
+#OVERLAY_BUNDLES=glibc_full,cf_cli,dhcp,dropbear,felix,java,links,lua,mll_utils,nano,ncurses,nweb,static_get,util_linux,zlib
+#OVERLAY_BUNDLES=glibc_full,dhcp,felix,links,openjdk,zlib
 
 # This property enables the standard penguin boot logo in the upper left corner
 # of the screen. The property is used in 'xx_build_kernel.sh'. The default value

--- a/src/README
+++ b/src/README
@@ -27,16 +27,7 @@ Currently available overlay bundles:
 
                This overlay bundle depends on the GLIBC build process.
 
-* ZLIB       - Software library used for data compression.
-
-               This overlay bundle is self sufficient and doesn't require other
-               overlay bundles.
-
-* Links      - text based browser. Requires ~1MB additional space. Use the
-               "links" command to activate the browser.
-
-               This overlay bundle is self sufficient and doesn't require other
-               overlay bundles.
+* dhcp       - DHCP and DNS functionality to connect to the Internet.
 
 * Dropbear   - SSH server/client. Requires ~1MB additional space. The build
                process creates user 'root' with password 'toor'. These are
@@ -47,6 +38,11 @@ Currently available overlay bundles:
 
                This overlay bundle requires GLIBC.
 
+* Felix OSGi - Apache Felix OSGi framework. Requires ~2MB additional space. Use
+               the "felix-start" command to run the Apache Felix OSGi framework.
+
+               This overlay bundle requires JRE or JDK.
+
 * JRE / JDK  - Oracle's JRE or JDK. Requires ~366MB additional space for JDK.
                This overlay bundle requires some manual preparation steps. Refer
                to the "JAVA_ARCHIVE" property in the ".config" file for more
@@ -54,14 +50,16 @@ Currently available overlay bundles:
 
                This overlay bundle requires GLIBC. JDK 9 requires ZLIB. 
 
+* Links      - Text based browser. Requires ~1MB additional space. Use the
+               "links" command to activate the browser.
+
 * Open JDK   - The open source JDK. No need for manual steps.
 
                This overlay bundle requires GLIBC and ZLIB.
 
-* Felix OSGi - Apache Felix OSGi framework. Requires ~2MB additional space. Use
-               the "felix-start" command to run the Apache Felix OSGi framework.
-
-               This overlay bundle requires JRE or JDK.
+* Lua        - The Lua Scripting Language 5.3. Requires ~ 800kb additional
+               space. Use the "lua" command to run an interactive lua
+               interpreter.
 
 * MLL Utils  - Set of experimental shell scripts (mll-*.sh) which provide
                additional functionality, e.g. installer and useful tools.
@@ -69,23 +67,25 @@ Currently available overlay bundles:
                This overlay bundle is currently experimental and its build
                process depends on the host machine.
 
-* Lua        - The Lua Scripting Language 5.3. Requires ~ 800kb additional
-               space. Use the "lua" command to run an interactive lua interpreter
+* nano       - Simple command-line text editor with on-screen shortcuts.
 
-* nano       - GNU nano is an enhanced clone of the Pico text editor
+               This overlay bundle requires ncurses.
 
-* ncurses    - 'GUI-like' API that runs within a terminal emulator
+* ncurses    - "GUI-like" API that runs within a terminal emulator.
 
-* nweb       - nweb is a very small and easy to use webserver, it is run automatically on port 80
-               to portforward port 80 from the guest (minimal) to port 8080 on the host add
-               '-net nic,model=e1000 -net user,hostfwd=tcp::8080-:80' to 'cmd' in qemu.sh
+* nweb       - nweb is a very small and easy to use webserver, it is run
+               automatically on port 80. To portforward port 80 from the
+               guest (minimal) to port 8080 on the host add
+               '-net nic,model=e1000 -net user,hostfwd=tcp::8080-:80' to
+               'cmd' in the qemu.sh file.
 
-* dhcp       - DHCP and DNS functionality
-
-* util_linux - util-linux is a standard package distributed by the Linux Kernel
-               Organization similar to busybox or GNU Core Utils.
+* util_linux - Set of executable utilities distributed by the Linux Kernel
+               similar to busybox or GNU Core Utils.
 
                Some packages in this overlay bundle require ncurses.
+
+* ZLIB       - Software library used for data compression.
+
 
 ###   ###   ###
 


### PR DESCRIPTION
I cleaned up the .config and README files.

-I added nano's ncurses dependency in the README.

-I changed the descriptions of the bundles that I added.

-I did not understand the order so I alphabetized the overlay_bundle entries while keeping glibc_full at the beginning because of its importance.

-I made the entries uniform with all capital or all lowercase letters at the beginning of each description.

-I made the entries uniform with periods at the end of each sentence or description.