### PR TITLE
Added the kbd bundle

### DIFF
--- a/src/.config
+++ b/src/.config
@@ -67,6 +67,11 @@ FELIX_SOURCE_URL=http://archive.apache.org/dist/felix/org.apache.felix.main.dist
 #JAVA_ARCHIVE=/absolute/path/to/java.archive.tar.gz
 #JAVA_ARCHIVE=/home/ivan/Downloads/jdk-9_linux-x64_bin.tar.gz
 
+# You can find the latest kbd source bundles here:
+#
+#   http://www.kbd-project.org/
+#
+KBD_SOURCE_URL=https://www.kernel.org/pub/linux/utils/kbd/kbd-2.0.4.tar.gz
 # You can find the latest kexec-tools source bundles here:
 #
 #   https://www.kernel.org/pub/linux/utils/kernel/kexec/
@@ -204,6 +209,7 @@ COPY_SOURCE_ISO=true
 # dropbear   - SSH server and client.
 # felix      - Apache Felix OSGi framework.
 # java       - installs Oracle's JRE or JDK. Manual preparations are required.
+# kbd        - keyboard utilities
 # links      - text browser for the web.
 # lua        - scripting language.
 # mll_utils  - set of executable utilities (mll-*).
@@ -217,7 +223,7 @@ COPY_SOURCE_ISO=true
 #
 # Refer to the README file for more information.
 #
-#OVERLAY_BUNDLES=glibc_full,cf_cli,dhcp,dropbear,felix,java,links,lua,mll_utils,nano,ncurses,nweb,static_get,util_linux,zlib
+#OVERLAY_BUNDLES=glibc_full,cf_cli,dhcp,dropbear,felix,java,kbd,links,lua,mll_utils,nano,ncurses,nweb,static_get,util_linux,zlib
 #OVERLAY_BUNDLES=glibc_full,dhcp,felix,links,openjdk,zlib
 
 # This property enables the standard penguin boot logo in the upper left corner

--- a/src/README
+++ b/src/README
@@ -50,6 +50,11 @@ Currently available overlay bundles:
 
                This overlay bundle requires GLIBC. JDK 9 requires ZLIB. 
 
+* kbd        - Keyboard utilities and keymaps, you can for example load
+               a german keyboard layout:
+
+                 loadkeys de
+
 * Links      - Text based browser. Requires ~1MB additional space. Use the
                "links" command to activate the browser.
 

--- a/src/minimal_overlay/bundles/kbd/01_get.sh
+++ b/src/minimal_overlay/bundles/kbd/01_get.sh
@@ -42,12 +42,13 @@ cd "$WORK_DIR/overlay/kbd"
 cd $(ls -d kbd-*)
 
 # rename keymaps with the same name
-mv data/keymaps/i386/qwertz/cz{,-qwertz}.map
-mv data/keymaps/i386/olpc/es{,-olpc}.map
-mv data/keymaps/i386/olpc/pt{,-olpc}.map
-mv data/keymaps/i386/dvorak/no{,-dvorak}.map
-mv data/keymaps/i386/fgGIod/trf{,-fgGIod}.map
-mv data/keymaps/i386/colemak/{en-latin9,colemak}.map
+mv data/keymaps/i386/qwertz/cz.map data/keymaps/i386/qwertz/cz-qwertz.map
+mv data/keymaps/i386/olpc/es.map data/keymaps/i386/olpc/es-olpc.map
+mv data/keymaps/i386/olpc/pt.map data/keymaps/i386/olpc/pt-olpc.map
+mv data/keymaps/i386/dvorak/no.map data/keymaps/i386/dvorak/no-dvorak.map
+mv data/keymaps/i386/fgGIod/trf.map data/keymaps/i386/fgGIod/trf-fgGIod.map
+mv data/keymaps/i386/colemak/en-latin9.map data/keymaps/i386/colemak/colemak.map
+
 
 cd $SRC_DIR
 

--- a/src/minimal_overlay/bundles/kbd/01_get.sh
+++ b/src/minimal_overlay/bundles/kbd/01_get.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+SRC_DIR=$(pwd)
+
+. ../../common.sh
+
+# Grab everything after the '=' character.
+DOWNLOAD_URL=$(grep -i KBD_SOURCE_URL $MAIN_SRC_DIR/.config | cut -f2 -d'=')
+
+# Grab everything after the last '/' character.
+ARCHIVE_FILE=${DOWNLOAD_URL##*/}
+
+# Read the 'USE_LOCAL_SOURCE' property from '.config'
+USE_LOCAL_SOURCE="$(grep -i USE_LOCAL_SOURCE $MAIN_SRC_DIR/.config | cut -f2 -d'=')"
+
+if [ "$USE_LOCAL_SOURCE" = "true" -a ! -f $MAIN_SRC_DIR/source/overlay/$ARCHIVE_FILE  ] ; then
+  echo "Source bundle $MAIN_SRC_DIR/source/overlay/$ARCHIVE_FILE is missing and will be downloaded."
+  USE_LOCAL_SOURCE="false"
+fi
+
+cd $MAIN_SRC_DIR/source/overlay
+
+if [ ! "$USE_LOCAL_SOURCE" = "true" ] ; then
+  # Downloading kbd source bundle file. The '-c' option allows the download to resume.
+  echo "Downloading kbd source bundle from $DOWNLOAD_URL"
+  wget -c $DOWNLOAD_URL
+else
+  echo "Using local kbd source bundle $MAIN_SRC_DIR/source/overlay/$ARCHIVE_FILE"
+fi
+
+# Delete folder with previously extracted kbd.
+echo "Removing kbd work area. This may take a while..."
+rm -rf $WORK_DIR/overlay/kbd
+mkdir $WORK_DIR/overlay/kbd
+
+# Extract kbd to folder 'work/overlay/kbd'.
+# Full path will be something like 'work/overlay/kbd/kbd-2.04'.
+tar -xvf $ARCHIVE_FILE -C $WORK_DIR/overlay/kbd
+
+cd "$WORK_DIR/overlay/kbd"
+
+cd $(ls -d kbd-*)
+
+# rename keymaps with the same name
+mv data/keymaps/i386/qwertz/cz{,-qwertz}.map
+mv data/keymaps/i386/olpc/es{,-olpc}.map
+mv data/keymaps/i386/olpc/pt{,-olpc}.map
+mv data/keymaps/i386/dvorak/no{,-dvorak}.map
+mv data/keymaps/i386/fgGIod/trf{,-fgGIod}.map
+mv data/keymaps/i386/colemak/{en-latin9,colemak}.map
+
+cd $SRC_DIR
+

--- a/src/minimal_overlay/bundles/kbd/02_build.sh
+++ b/src/minimal_overlay/bundles/kbd/02_build.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+SRC_DIR=$(pwd)
+
+. ../../common.sh
+
+cd $WORK_DIR/overlay/kbd
+
+DESTDIR="$PWD/kbd_installed"
+
+# Change to the kbd source directory which ls finds, e.g. 'kbd-2.04'.
+cd $(ls -d kbd-*)
+
+echo "Preparing kbd work area. This may take a while..."
+make -j $NUM_JOBS clean
+rm -rf $DESTDIR
+
+echo "Configuring kbd..."
+CFLAGS="$CFLAGS" ./configure \
+  --prefix=/usr
+
+echo "Building kbd..."
+make -j $NUM_JOBS
+
+echo "Installing kbd..."
+make -j $NUM_JOBS install DESTDIR="$DESTDIR"
+
+echo "Reducing kbd size..."
+strip -g \
+  $DESTDIR/usr/bin/* \
+  $DESTDIR/usr/sbin/* \
+  $DESTDIR/lib/*
+
+ROOTFS=$WORK_DIR/src/minimal_overlay/rootfs
+
+mkdir -p $ROOTFS/usr
+cp -r "$DESTDIR/usr/bin" \
+  "$DESTDIR/usr/share" \
+  "$ROOTFS/usr/"
+
+echo "kbd has been installed."
+
+cd $SRC_DIR
+

--- a/src/minimal_overlay/bundles/kbd/02_build.sh
+++ b/src/minimal_overlay/bundles/kbd/02_build.sh
@@ -17,7 +17,9 @@ rm -rf $DESTDIR
 
 echo "Configuring kbd..."
 CFLAGS="$CFLAGS" ./configure \
-  --prefix=/usr
+  --prefix=/usr \
+  --disable-vlock
+# vlock requires PAM
 
 echo "Building kbd..."
 make -j $NUM_JOBS

--- a/src/minimal_overlay/bundles/kbd/bundle.sh
+++ b/src/minimal_overlay/bundles/kbd/bundle.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+SRC_DIR=$(pwd)
+
+./01_get.sh
+./02_build.sh
+
+cd $SRC_DIR
+


### PR DESCRIPTION
Its time to end this madness, load a german keyboard layout using:
```bash
loadkeys de
```

This bundle adds about 4.6mb, you could reduce its size by removing some of the generated keymaps and consolefonts in `/usr/share/`