### PR TITLE
Replace COPY_SOURCE_ISO with a src bundle

### DIFF
--- a/src/.config
+++ b/src/.config
@@ -216,11 +216,6 @@ OVERLAY_TYPE=folder
 # Live" with predefined sources.
 USE_LOCAL_SOURCE=false
 
-# Copy "Minimal Linux Live" source files and folders in '/src' inside initramfs.
-# The default value is 'true'. You can use any other value, no value, or comment
-# the property in order to disable it.
-COPY_SOURCE_ROOTFS=true
-
 # This property defines one or more additional overlay software pieces which
 # will be generated and placed in the 'work/src/minimal_overlay/rootfs' folder.
 # These software pieces will be visible and fully usable after boot. By default

--- a/src/.config
+++ b/src/.config
@@ -221,11 +221,6 @@ USE_LOCAL_SOURCE=false
 # the property in order to disable it.
 COPY_SOURCE_ROOTFS=true
 
-# Copy "Minimal Linux Live" source files and folders in '/src' on the ISO image.
-# The default value is 'true'. You can use any other value, no value, or comment
-# the property in order to disable it.
-COPY_SOURCE_ISO=true
-
 # This property defines one or more additional overlay software pieces which
 # will be generated and placed in the 'work/src/minimal_overlay/rootfs' folder.
 # These software pieces will be visible and fully usable after boot. By default
@@ -258,6 +253,7 @@ COPY_SOURCE_ISO=true
 # ncurses     - "GUI-like" API that runs within a terminal emulator.
 # nweb        - simple mini http server.
 # openjdk     - installs Open JDK. All operations are automated.
+# src         - a copy of the source at /usr/src
 # static_get  - portable binaries for Linux (http://s.minos.io).
 # stress      - CPU and RAM load generator.
 # util_linux  - set of executable utilities distributed by the Linux Kernel Org.

--- a/src/09_generate_rootfs.sh
+++ b/src/09_generate_rootfs.sh
@@ -27,18 +27,6 @@ cd rootfs
 # Remove 'linuxrc' which is used when we boot in 'RAM disk' mode.
 rm -f linuxrc
 
-# Read the 'COPY_SOURCE_ROOTFS' property from '.config'
-COPY_SOURCE_ROOTFS="$(grep -i ^COPY_SOURCE_ROOTFS $SRC_ROOT/.config | cut -f2 -d'=')"
-
-if [ "$COPY_SOURCE_ROOTFS" = "true" ] ; then
-  # Copy all prepared source files and folders to '/src'. Note that the scripts
-  # will not work there because you also need proper toolchain.
-  cp -r ../src src
-  echo "Source files and folders have been copied to '/src'."
-else
-  echo "Source files and folders have been skipped."
-fi
-
 # This is for the dynamic loader. Note that the name and the location are both
 # specific for 32-bit and 64-bit machines. First we check the BusyBox executable
 # and then we copy the dynamic loader to its appropriate location.

--- a/src/12_generate_iso.sh
+++ b/src/12_generate_iso.sh
@@ -3,11 +3,10 @@
 # TODO - this shell script file needs serios refactoring since right now it does
 # too many things:
 #
-# 1) Deal with 'src' copy.
-# 2) Generate the 'overlay' software bundles.
-# 3) Create proper overlay structure.
-# 4) Prepare the actual ISO structure.
-# 5) Generate the actual ISO image.
+# 1) Generate the 'overlay' software bundles.
+# 2) Create proper overlay structure.
+# 3) Prepare the actual ISO structure.
+# 4) Generate the actual ISO image.
 #
 # Probably it's best to create separate shell scripts for each functionality.
 
@@ -35,18 +34,6 @@ rm -rf work/isoimage
 # This is the root folder of the ISO image.
 mkdir work/isoimage
 echo "Prepared new ISO image work area."
-
-# Read the 'COPY_SOURCE_ISO' property from '.config'
-COPY_SOURCE_ISO="$(grep -i ^COPY_SOURCE_ISO .config | cut -f2 -d'=')"
-
-if [ "$COPY_SOURCE_ISO" = "true" ] ; then
-  # Copy all prepared source files and folders to '/src'. Note that the scripts
-  # will not work there because you also need proper toolchain.
-  cp -r work/src work/isoimage
-  echo "Source files and folders have been copied to '/src'."
-else
-  echo "Source files and folders have been skipped."
-fi
 
 # Read the 'OVERLAY_BUNDLES' property from '.config'
 OVERLAY_BUNDLES="$(grep -i ^OVERLAY_BUNDLES .config | cut -f2 -d'=')"

--- a/src/README
+++ b/src/README
@@ -100,6 +100,11 @@ Currently available overlay bundles:
                 '-net nic,model=e1000 -net user,hostfwd=tcp::8080-:80' to
                 'cmd' in the qemu.sh file.
 
+* src         - A copy of all prepared MLL source files and folders at
+                /usr/src Note that the scripts will not work there because
+                you also need a proper toolchain.
+                This bundle was previously COPY_SOURCE_ISO
+
 * stress      - simple workload generator. Imposes a configurable amount of CPU,
                 memory, I/O, and disk stress on the system. stress is useful for
                 troubleshooting CPU and RAM.

--- a/src/minimal_overlay/bundles/src/bundle.sh
+++ b/src/minimal_overlay/bundles/src/bundle.sh
@@ -10,7 +10,9 @@ mkdir -p ./minimal_overlay/rootfs/usr/src
 
 shopt -s extglob
 
-cp -r ./!(minimal_overlay/rootfs) ./minimal_overlay/rootfs/usr/src
+cp -r ./!(minimal_overlay) ./minimal_overlay/rootfs/usr/src
+mkdir -p ./minimal_overlay/rootfs/usr/src/minimal_overlay
+cp -r ./minimal_overlay/!(rootfs) ./minimal_overlay/rootfs/usr/src/minimal_overlay/
 
 shopt -u extglob
 

--- a/src/minimal_overlay/bundles/src/bundle.sh
+++ b/src/minimal_overlay/bundles/src/bundle.sh
@@ -1,16 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 
 SRC_DIR=$(pwd)
 
 . ../../common.sh
 
-cd $SRC_DIR
-
 cd $WORK_DIR/src
 
-ROOTFS="$WORK_DIR/src/minimal_overlay/rootfs"
+mkdir -p ./minimal_overlay/rootfs/usr/src
 
-mkdir -p "$ROOTFS/usr"
-cp -r "$WORK_DIR/src" "$ROOTFS/usr/src"
+shopt -s extglob
 
-echo "Source files and folders have been copied to '/src'."
+cp -r ./!(minimal_overlay/rootfs) ./minimal_overlay/rootfs/usr/src
+
+shopt -u extglob
+
+echo "Source files and folders have been copied to '/usr/src'."
+
+cd $SRC_DIR

--- a/src/minimal_overlay/bundles/src/bundle.sh
+++ b/src/minimal_overlay/bundles/src/bundle.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+SRC_DIR=$(pwd)
+
+. ../../common.sh
+
+cd $SRC_DIR
+
+cd $WORK_DIR/src
+
+ROOTFS="$WORK_DIR/src/minimal_overlay/rootfs"
+mkdir -p "$ROOTFS/usr/src"
+
+# maybe use find instead
+shopt -s extglob
+cp -r !("$ROOTFS") "$WORK_DIR/src" "$ROOTFS/usr/src"
+shopt +u extglob
+
+echo "Source files and folders have been copied to '/src'."

--- a/src/minimal_overlay/bundles/src/bundle.sh
+++ b/src/minimal_overlay/bundles/src/bundle.sh
@@ -9,11 +9,8 @@ cd $SRC_DIR
 cd $WORK_DIR/src
 
 ROOTFS="$WORK_DIR/src/minimal_overlay/rootfs"
-mkdir -p "$ROOTFS/usr/src"
 
-# maybe use find instead
-shopt -s extglob
-cp -r !("$ROOTFS") "$WORK_DIR/src" "$ROOTFS/usr/src"
-shopt +u extglob
+mkdir -p "$ROOTFS/usr"
+cp -r "$WORK_DIR/src" "$ROOTFS/usr/src"
 
 echo "Source files and folders have been copied to '/src'."


### PR DESCRIPTION
This reduces the tasks performed by `12_generate_iso.sh`.
It doesn't copy `work/src/minimal_overlay/rootfs`, since that would be recursive.