### PR TITLE
Added the ability to install software using static-get

### DIFF
--- a/src/.config
+++ b/src/.config
@@ -11,13 +11,13 @@
 #
 #   http://kernel.org
 #
-KERNEL_SOURCE_URL=http://kernel.org/pub/linux/kernel/v5.x/linux-5.0.11.tar.xz
+KERNEL_SOURCE_URL=http://kernel.org/pub/linux/kernel/v5.x/linux-5.2.9.tar.xz
 
 # You can find the latest GNU C library source bundles here:
 #
 #   http://gnu.org/software/libc
 #
-GLIBC_SOURCE_URL=http://ftp.gnu.org/gnu/glibc/glibc-2.29.tar.bz2
+GLIBC_SOURCE_URL=http://ftp.gnu.org/gnu/glibc/glibc-2.30.tar.bz2
 
 # You can find the latest Busybox source bundles here:
 #

--- a/src/minimal_overlay/bundles/static_get/.config
+++ b/src/minimal_overlay/bundles/static_get/.config
@@ -3,4 +3,4 @@
 #   http://s.minos.io/s
 #   http://github.com/minos-org/minos-static
 #
-STATIC_GET_URL=http://github.com/the-djdj/minos-static
+STATIC_GET_URL=http://raw.githubusercontent.com/the-djdj/minos-static/master/static-get

--- a/src/minimal_overlay/bundles/static_get/.config
+++ b/src/minimal_overlay/bundles/static_get/.config
@@ -3,4 +3,4 @@
 #   http://s.minos.io/s
 #   http://github.com/minos-org/minos-static
 #
-STATIC_GET_URL=http://s.minos.io/s
+STATIC_GET_URL=http://github.com/the-djdj/minos-static


### PR DESCRIPTION
I've changed the upstream of the `static-get` overlay bundle to my own fork, so that software can be installed. The idea is that this is temporary while my pull request for that project is approved, but for now, this works.