### PR TITLE
Fix vim dependencies

### DIFF
--- a/src/minimal_overlay/bundles/ncurses/02_build.sh
+++ b/src/minimal_overlay/bundles/ncurses/02_build.sh
@@ -31,7 +31,7 @@ CFLAGS="$CFLAGS" ./configure \
     --without-normal \
     --without-debug \
     --without-cxx-binding \
-    --with-abi-version=5 \
+    --with-abi-version=6 \
     --enable-widec \
     --enable-pc-files \
     --with-shared \

--- a/src/minimal_overlay/bundles/vim/02_build.sh
+++ b/src/minimal_overlay/bundles/vim/02_build.sh
@@ -29,7 +29,9 @@ CFLAGS="$CFLAGS" ./configure \
   --with-tlib=ncurses \
   --disable-xsmp \
   --disable-gpm \
-  --disable-selinux
+  --disable-selinux \
+  --disable-canberra \
+  --disable-acl
 
 export CONF_OPT_GUI='--enable-gui=no'
 export CONF_OPT_PERL='--enable-perlinterp'


### PR DESCRIPTION
vim is currently builded with the dependencies for libcanberra and libacl. But these dependencies doesn't show up in the bundles. So in order to fix it, I just changed the build to not include these dependencies. Furthermore vim needs libncursesw.so.6 in order to start. So I just changed the version of the ncurses build from 5 to 6.