### PR TITLE
Fix GCC compile error

### DIFF
--- a/src/04_build_glibc.sh
+++ b/src/04_build_glibc.sh
@@ -36,6 +36,7 @@ $GLIBC_SRC/configure \
   --without-gd \
   --without-selinux \
   --disable-werror \
+  --enable-cet \
   CFLAGS="$CFLAGS"
 
 # Compile glibc with optimization for "parallel jobs" = "number of processors".


### PR DESCRIPTION
I've encountered the same GCC compile error as he did. 

[Example from stack overflow with Solution](https://stackoverflow.com/questions/58995065/undefined-reference-to-dl-cet-check-while-building-glibc)
> Apparently, your GCC version implicitly enables the -fcf-protection flag. Upstream GCC does not do this, so the glibc configure logic is not prepared for this. You will have to configure explicitly with CET, like this:
>```$ $HOME/src/glibc/configure --prefix=/usr --enable-cet```
>As a result, the CET support functionality will be linked in.