### PR TITLE
Added missing dependencies to python overlay

### DIFF
--- a/src/minimal_overlay/bundles/python/bundle_deps
+++ b/src/minimal_overlay/bundles/python/bundle_deps
@@ -1,2 +1,3 @@
 glibc_libpthread
 glibc_libutil
+libxcrypt

--- a/src/minimal_overlay/bundles/python/bundle_deps
+++ b/src/minimal_overlay/bundles/python/bundle_deps
@@ -1,3 +1,4 @@
 glibc_libpthread
 glibc_libutil
+glibc_libdl
 libxcrypt


### PR DESCRIPTION
The python application can not be started in the live system and fails with the following error messages:

```text
python3: error while loading shared libraries: libcrypt.so.1: cannot open shared object file: No such file or directory
python3: error while loading shared libraries: libdl.so.2: cannot open shared object file: No such file or directory
```

This indicates that a dependency for the missing libraries exists and is required for the built Python version.
This MR adds the following missing dependencies to the overlay:

- glibc_libdl
-  libxcrypt
