### PR TITLE
Added bundle to build GCC support library (libgcc_s.so)

### DIFF
--- a/src/minimal_overlay/bundles/libgcc_s/.config
+++ b/src/minimal_overlay/bundles/libgcc_s/.config
@@ -1,0 +1,5 @@
+# You can find the latest nano source bundles here:
+#
+#   https://ftpmirror.gnu.org/gcc/
+#
+GCC_SOURCE_URL=https://ftpmirror.gnu.org/gcc/gcc-11.1.0/gcc-11.1.0.tar.xz

--- a/src/minimal_overlay/bundles/libgcc_s/01_get.sh
+++ b/src/minimal_overlay/bundles/libgcc_s/01_get.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -e
+
+. ../../common.sh
+
+# Read the common configuration properties.
+DOWNLOAD_URL=`read_property GCC_SOURCE_URL`
+USE_LOCAL_SOURCE=`read_property USE_LOCAL_SOURCE`
+
+# Grab everything after the last '/' character.
+ARCHIVE_FILE=${DOWNLOAD_URL##*/}
+
+if [ "$USE_LOCAL_SOURCE" = "true" -a ! -f $MAIN_SRC_DIR/source/overlay/$ARCHIVE_FILE  ] ; then
+  echo "Source bundle $MAIN_SRC_DIR/source/overlay/$ARCHIVE_FILE is missing and will be downloaded."
+  USE_LOCAL_SOURCE="false"
+fi
+
+cd $MAIN_SRC_DIR/source/overlay
+
+if [ ! "$USE_LOCAL_SOURCE" = "true" ] ; then
+  # Downloading gcc source bundle file. The '-c' option allows the download to resume.
+  echo "Downloading gcc source bundle from $DOWNLOAD_URL"
+  wget -c $DOWNLOAD_URL
+else
+  echo "Using local gcc source bundle $MAIN_SRC_DIR/source/overlay/$ARCHIVE_FILE"
+fi
+
+# Delete folder with previously extracted gcc.
+echo "Removing gcc work area. This may take a while."
+rm -rf $WORK_DIR/overlay/$BUNDLE_NAME
+mkdir $WORK_DIR/overlay/$BUNDLE_NAME
+
+# Extract gcc to folder 'work/overlay/gcc'.
+# Full path will be something like 'work/overlay/gcc/gcc-11.1.0'.
+tar -xvf $ARCHIVE_FILE -C $WORK_DIR/overlay/$BUNDLE_NAME
+
+cd $SRC_DIR

--- a/src/minimal_overlay/bundles/libgcc_s/02_build.sh
+++ b/src/minimal_overlay/bundles/libgcc_s/02_build.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -e
+
+. ../../common.sh
+
+cd $WORK_DIR/overlay/$BUNDLE_NAME
+
+# Change to the gcc source directory which ls finds, e.g. 'gcc-11.1.0'.
+cd $(ls -d gcc-*)
+
+if [ -f Makefile ] ; then
+  echo "Preparing '$BUNDLE_NAME' work area. This may take a while."
+  make -j $NUM_JOBS clean || true
+else
+  echo "The clean phase for '$BUNDLE_NAME' has been skipped."
+fi
+
+rm -rf $DEST_DIR
+
+echo "Configuring '$BUNDLE_NAME'."
+CFLAGS="$CFLAGS" ./configure \
+  --prefix=/usr \
+  --enable-languages=c \
+  --disable-multilib \
+  --disable-static \
+  --disable-libquadmath \
+  --enable-shared
+
+echo "Building '$BUNDLE_NAME'."
+make -j $NUM_JOBS all-gcc
+make -j $NUM_JOBS all-target-libgcc
+
+echo "Installing '$BUNDLE_NAME'."
+make -j $NUM_JOBS install-target-libgcc DESTDIR=$DEST_DIR
+
+mkdir -p $OVERLAY_ROOTFS/lib
+# With '--remove-destination' all possibly existing soft links in
+# '$OVERLAY_ROOTFS' will be overwritten correctly.
+cp -r --remove-destination $DEST_DIR/usr/lib64/libgcc_s.so* \
+  $OVERLAY_ROOTFS/lib/
+
+echo "Bundle '$BUNDLE_NAME' has been installed."
+
+cd $SRC_DIR

--- a/src/minimal_overlay/bundles/libgcc_s/bundle.sh
+++ b/src/minimal_overlay/bundles/libgcc_s/bundle.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+. ../../common.sh
+
+./01_get.sh
+./02_build.sh
+
+cd $SRC_DIR


### PR DESCRIPTION
The function pthread_cancel requires the GCC support library libgcc_s.so.1 to be present.
The added bundle enables to build this support library and install it into the /lib overlay directlory.
The compilation of the support library currently requires the compilation of GCC due to internal make target dependencies.