### PR TITLE
Added kernel module support

### DIFF
--- a/src/.config
+++ b/src/.config
@@ -67,6 +67,13 @@ FIRMWARE_TYPE=bios
 #
 USE_PREDEFINED_KERNEL_CONFIG=false
 
+# Build kernel modules and make them available in the overlayfs / rootfs in the
+# /lib/modules directory. The modules can be loaded via 'insmod' to support
+# additional periphery and software devices.
+# Note however, that the essential drivers to load the overlayfs have to be
+# included in the kernel as the overlayfs might not be loaded otherwise.
+BUILD_KERNEL_MODULES=false
+
 # Use predefined '.config' file when building Busybox. This overrides the
 # config generation in 'xx_build_busybox.sh' and the build process uses the
 # config file provided in this parameter. Place the configuration file here:

--- a/src/09_generate_rootfs.sh
+++ b/src/09_generate_rootfs.sh
@@ -5,6 +5,8 @@ set -e
 # Load common properties and functions in the current script.
 . ./common.sh
 
+BUILD_KERNEL_MODULES=`read_property BUILD_KERNEL_MODULES`
+
 echo "*** GENERATE ROOTFS BEGIN ***"
 
 echo "Preparing rootfs work area. This may take a while."
@@ -69,6 +71,12 @@ if [ "$OVERLAY_LOCATION" = "rootfs" ] && \
     $OVERLAY_ROOTFS/* $ROOTFS
   cp -r --remove-destination \
     $SRC_DIR/minimal_overlay/rootfs/* $ROOTFS
+
+  # Copy all modules to the sysroot folder.
+  if [ "$BUILD_KERNEL_MODULES" = "true" ] ; then
+    echo "Copying modules. This may take a while."
+    cp -r --remove-destination $KERNEL_INSTALLED/lib $ROOTFS
+  fi
 fi
 
 echo "The rootfs area has been generated."

--- a/src/11_generate_overlay.sh
+++ b/src/11_generate_overlay.sh
@@ -21,6 +21,8 @@ OVERLAY_TYPE=`read_property OVERLAY_TYPE`
 # Read the 'OVERLAY_LOCATION' property from '.config'
 OVERLAY_LOCATION=`read_property OVERLAY_LOCATION`
 
+BUILD_KERNEL_MODULES=`read_property BUILD_KERNEL_MODULES`
+
 if [ "$OVERLAY_LOCATION" = "iso" ] && \
    [ "$OVERLAY_TYPE" = "sparse" ] && \
    [ -d $OVERLAY_ROOTFS ] && \
@@ -64,6 +66,12 @@ if [ "$OVERLAY_LOCATION" = "iso" ] && \
   cp -r $SRC_DIR/minimal_overlay/rootfs/* \
     $ISOIMAGE_OVERLAY/sparse/rootfs
 
+  # Copy all modules to the sysroot folder.
+  if [ "$BUILD_KERNEL_MODULES" = "true" ] ; then
+    echo "Copying modules. This may take a while."
+    cp -r $KERNEL_INSTALLED/lib $ISOIMAGE_OVERLAY/sparse/rootfs
+  fi
+
   # Unmount the sparse file and delete the temporary folder.
   sync
   $BUSYBOX umount $ISOIMAGE_OVERLAY/sparse
@@ -92,6 +100,12 @@ elif [ "$OVERLAY_LOCATION" = "iso" ] && \
     $ISOIMAGE_OVERLAY/minimal/rootfs
   cp -r $SRC_DIR/minimal_overlay/rootfs/* \
     $ISOIMAGE_OVERLAY/minimal/rootfs
+
+  # Copy all modules to the sysroot folder.
+  if [ "$BUILD_KERNEL_MODULES" = "true" ] ; then
+    echo "Copying modules. This may take a while."
+    cp -r $KERNEL_INSTALLED/lib $ISOIMAGE_OVERLAY/minimal/rootfs
+  fi
 else
   echo "The ISO image will have no overlay structure."
 fi


### PR DESCRIPTION
Adds support for loadable kernel modules to support real hardware. This also indirectly concerns #162 as "real hardware" can now be addressed. The kernel modules are stored in the rootfs or overlayfs depending on the configuration set by the user.

I have tested the configuration combination of "OVERLAY_LOCATION=iso" and "OVERLAY_TYPE=folder".
The configurations "OVERLAY_LOCATION=rootfs" and "OVERLAY_TYPE=sparse" have been implemented but are untested.