### PR TITLE
Fix: ncurse 6 and missing lib

### DIFF
--- a/src/minimal_overlay/bundles/ncurses/02_build.sh
+++ b/src/minimal_overlay/bundles/ncurses/02_build.sh
@@ -52,11 +52,16 @@ echo "Installing '$BUNDLE_NAME'."
 make -j $NUM_JOBS install DESTDIR=$DEST_DIR
 
 # Symnlink wide character libraries
-cd $DEST_DIR/usr/lib
-ln -s libncursesw.so.5 libncurses.so.5
-ln -s libncurses.so.5 libncurses.so
-ln -s libtinfow.so.5 libtinfo.so.5
-ln -s libtinfo.so.5 libtinfo.so
+if [ -d "$DEST_DIR/usr/lib" ]
+then
+  cd $DEST_DIR/usr/lib
+else
+  cd $DEST_DIR/usr/lib64
+fi
+ln -s libncursesw.so.6 libncurses.so.6
+ln -s libncurses.so.6 libncurses.so
+ln -s libtinfow.so.6 libtinfo.so.6
+ln -s libtinfo.so.6 libtinfo.so
 
 echo "Reducing '$BUNDLE_NAME' size."
 set +e


### PR DESCRIPTION
ncurse bundel sources are now based on v6, but links still refers to 5, so end broken.
Also, depending on platform used, sometime I found that /usr/lib was instead /usr/lib64, so this check which one to use.