### PR TITLE
Fix: writing iso to usb

### DIFF
--- a/src/write_to_media.sh
+++ b/src/write_to_media.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# A minimal script which writes the produced iso into usb
+# with the help of the dd command
+
+set -e
+
+. ./common.sh
+
+ISO_NAME=$SRC_DIR/minimal_linux_live.iso
+
+if ! [ -e $ISO_NAME ]; then 
+	echo "You have to build the iso before running this script!"
+	exit 1
+
+elif [ "$#" -ne 1 ]; then
+	echo "Invocation: $0 [DEVICE_NAME] "
+	echo "Example: $0 /dev/sda "
+	exit 1
+else 
+	sudo dd if=$ISO_NAME of=$1 bs=4M && sync
+fi
+

--- a/src/write_to_media.sh
+++ b/src/write_to_media.sh
@@ -14,10 +14,11 @@ if ! [ -e $ISO_NAME ]; then
 	exit 1
 
 elif [ "$#" -ne 1 ]; then
-	echo "Invocation: $0 [DEVICE_NAME] "
-	echo "Example: $0 /dev/sda "
+	echo "Usage: $0 [DEVICE_NAME] (eg. $0 /dev/sda)"
 	exit 1
 else 
+	echo "CAUTION: All data on device $1 will be erased"
+	echo "You have been warned"
 	sudo dd if=$ISO_NAME of=$1 bs=4M && sync
 fi
 


### PR DESCRIPTION
Added a script, write_to_media.sh which writes the produced iso (i.e minimum_linux_live.iso) into a usb device with dd 